### PR TITLE
Enable builds for 2017, 2018, post builds to more permanent location. Enable diffing.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,6 +2,7 @@
 //Leave the above line alone.  It identifies this as a groovy script.
 @Library('vs-build-tools') _
 
-def lvVersions = ['2018']
+def lvVersions = ['2017', '2018']
 
 ni.vsbuild.PipelineExecutor.execute(this, 'veristand', lvVersions)
+diffPipeline('2017')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,4 +5,4 @@
 def lvVersions = ['2017', '2018']
 
 ni.vsbuild.PipelineExecutor.execute(this, 'veristand', lvVersions)
-diffPipeline('2017')
+diffPipeline(lvVersions[0])

--- a/build.toml
+++ b/build.toml
@@ -1,6 +1,6 @@
 [archive]
 build_output_dir = 'Custom Device Source'
-archive_location = '\\nirvana\temp\vs_cds\scan_engine_fxp'
+archive_location = '\\nirvana\Measurements\VeriStandAddons\scan_engine_fxp'
 
 [projects.fxp]
 path = 'Source\FXP LLB.lvproj'


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-scan-engine-fxp-libraries/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?
Enable builds for 2017, 2018, post builds to more permanent location.
Enable diffing.

### Why should this Pull Request be merged?
Right now we only build for 2018, and our builds are ephemeral.

### What testing has been done?
This pull request will be built.