### PR TITLE
Build 2017-2019

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 //Leave the above line alone.  It identifies this as a groovy script.
 @Library('vs-build-tools') _
 
-def lvVersions = ['2017', '2018']
+def lvVersions = ['2017', '2018', '2019']
 
 ni.vsbuild.PipelineExecutor.execute(this, 'veristand', lvVersions)
 diffPipeline(lvVersions[0])


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-scan-engine-fxp-libraries/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Builds 2017-2019 versions of the FXP libraries

### Why should this Pull Request be merged?

We need 2019 versions of the libraries to build 2019 versions of the custom device.

### What testing has been done?

Built
