### PR TITLE
Update Jenkinsfile to support VeriStand 2017-2020

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 //Leave the above line alone.  It identifies this as a groovy script.
 @Library('vs-build-tools') _
 
-def lvVersions = ['2017', '2018', '2019']
+def lvVersions = ['2017', '2018', '2019', '2020']
 
 ni.vsbuild.PipelineExecutor.execute(this, 'veristand', lvVersions)
 diffPipeline(lvVersions[0])


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-scan-engine-fxp-libraries/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Update Jenkinsfile to support VeriStand 2017-2020.

### Why should this Pull Request be merged?

This enables the Scan Engine Custom Device to build for VeriStand 2020.

### What testing has been done?

Successfully ran the build pipeline on the branch.
