### PR TITLE
Enable 2021 32-bit and 64-bit builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,10 @@
 //Leave the above line alone.  It identifies this as a groovy script.
 @Library('vs-build-tools') _
 
-def lvVersions = ['2019', '2020']
+def lvVersions = [
+  32 : ['2019', '2020', '2021'],
+  64 : ['2021']
+]
 
 ni.vsbuild.PipelineExecutor.execute(this, 'vs_cd_build', lvVersions)
 diffPipeline(lvVersions[0])


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-scan-engine-fxp-libraries/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Enable 2021 32-bit and 64-bit builds of the FXP LLBs

### Why should this Pull Request be merged?

Allow the main SEECD repo build for 2021

### What testing has been done?

Used this dev branch to successfully build the main repo
