### PR TITLE
Remove unnecessary driver dependencies from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,6 @@ These are the source VIs used to script and build (into an LLB) the FXP UDV read
 
 LabVIEW 2019
 
-## Dependencies
-
-- NI CompactRIO
-- NI-Industrial Communications for EtherCAT
-
 ## Git History & Rebasing Policy
 Branch rebasing and other history modifications will be listed here, with several notable exceptions:
 - Branches prefixed with `dev/` may be rebased, overwritten, or deleted at any time.


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-scan-engine-fxp-libraries/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Remove unnecessary driver dependencies from the readme.
This repo has a simple LabVIEW project and no driver-specific calls.
![image](https://user-images.githubusercontent.com/31290917/154539663-85ac4ff7-e358-4ace-94d0-69d13a58bd45.png)

### Why should this Pull Request be merged?

Doing a quick audit of our repo's readmes, and this stood out.

### What testing has been done?

None
