### PR TITLE
Add 2023 to build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,8 +3,8 @@
 @Library('vs-build-tools') _
 
 def lvVersions = [
-  32 : ['2019', '2020', '2021'],
-  64 : ['2021']
+  32 : ['2019', '2020', '2021', '2023'],
+  64 : ['2021', '2023']
 ]
 
 ni.vsbuild.PipelineExecutor.execute(this, 'vs_cd_build', lvVersions)


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-scan-engine-fxp-libraries/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Create a LV 2023-based build of the FXP libraries.

Note: leaving 2019 enabled until we disable it from all dependent repos.

### Why should this Pull Request be merged?

We need a good build against in-dev 2023 to run automated testing.

### What testing has been done?

PR build.

