### PR TITLE
Revert "Drop 32bit lv support (#36)"

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,9 +19,15 @@ stages:
 
       lvVersionsToBuild:
         - version: '2023'
-          bitness: '64bit'
+          bitness: '32bit'
+        - version: '2023'
+          bitness: '64bit'          
+        - version: '2024'
+          bitness: '32bit'
         - version: '2024'
           bitness: '64bit'
+        - version: '2025'
+          bitness: '32bit'
         - version: '2025'
           bitness: '64bit'
 


### PR DESCRIPTION
This reverts commit df2e7de403491762c6b206f9b6ae0716ca7f53f0.

- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-scan-engine-fxp-libraries/blob/main/CONTRIBUTING.md).

TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/niveristand-scan-engine-fxp-libraries/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Reverted the changes related to dropping 32-bit LabVIEW support, as building the Scan Engine Custom Device requires LabVIEW 32-bit

### Why should this Pull Request be merged?

Required for future release.

### What testing has been done?

PR Build.